### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,38 @@
 
 Developed by Dan Trueman and Michael Mulshine.
 
-bitKlavier takes inspiration from John Cage's <i>prepared piano</i>, but instead of screws and erasers we place a reconfigurable collection of digital machines between the virtual strings of the digital piano. Learn more at the <a href=http://bitklavier.com>bitKlavier website</a>.
+bitKlavier takes inspiration from John Cage's *prepared piano*, but instead of screws and erasers we place a reconfigurable collection of digital machines between the virtual strings of the digital piano. Learn more at the [bitKlavier website](http://bitklavier.com).
 
-Our code here is made available under the <a href=https://www.gnu.org/licenses/quick-guide-gplv3.en.html>GPLv3 license</a>; to compile, you will need <a href=http://juce.com>JUCE</a>, the C++ audio programming framework (<a href=https://github.com/WeAreROLI/JUCE>also released under GPLv3</a>), as well as <a href=https://www.steinberg.net/en/company/developers.html>Steinberg's VST-SDK</a> (released under their own license) if you want to target VST plugins.
+bitKlavier is built with [JUCE](http://juce.com>), the C++ audio programming framework ([available under GPLv3 license](https://github.com/WeAreROLI/JUCE)).
+
+Development on bitKlavier is sponsored by the [Center for Digital Humanities @ Princeton University](https://cdh.princeton.edu/).  See the [CDH project page](https://cdh.princeton.edu/projects/bitklavier/) for more details.
+
+## License
+
+This project is made available under the [GPLv3 license](https://www.gnu.org/licenses/quick-guide-gplv3.en.html)
+
+## Installation
+
+bitKlavier is currently in beta. See [releases](https://github.com/Princeton-CDH/bitKlavier/releases)
+to download the latest version.  The current version requires that you also
+download a [resource package with samples and galleries](http://manyarrowsmusic.com/bitKlavier/bitKlavier_ModelB/bitKlavier_resources.zip).  Currently, this resource folder must be placed in your
+Documents folder.
+
+## Development setup and instructions
+
+Branches in this git repository are named based on [git flow](https://github.com/nvie/gitflow) branching
+conventions; *master* contains code for the current release, new feature development
+for the next release is in *dev*.
+
+Download [JUCE and Projucer](https://juce.com/get-juce/download) for your platform,
+install the [appropriate compiler and devlopment tools](https://www.juce.com/learn/getting-started),
+and open the project in Projucer.  Code is structured in the standard
+Model-View-Controller design pattern.
+
+To compile bitKlavier as a VST plugin, you will also need
+[Steinberg's VST-SDK](https://www.steinberg.net/en/company/developers.html).
+
+To run your locally compiled version of bitKlavier, you will also need the
+resource folder (see Installation above).
+
+


### PR DESCRIPTION
I've made some updates to your readme for you to review.  This is in part to help with closing out the last year of work, and also to document some of the things I ran into when I was getting my local development environment set up.

Includes:
- conversion to markdown formatting (should be simpler to read/maintain)
- added sections for license, installation, and development setup
- added link to CDH website and project page per instructions in your charter
- added note & link about the required resources file (when I was getting my dev environment setup, bk built just fine but wouldn't run at all - it was only after I remembered the instructions for testing that I was able to get it to run)

You will probably want to make some additional edits.  Here are my recommendations:
- I know you have other funders/sponsors; I recommend listing & linking them alongside CDH
- Providing brief (one-line) descriptions of key terms (piano, gallery, preparation) as they are used in the app would be very helpful for someone trying to get oriented to the code (could go directly in the readme, or if you want to put it somewhere else we should link from the readme)
- Consider uploading the resource file to be included with your GitHub release.  I think this might make it easier to version and associate with the appropriate release, and it would hopefully make it more obvious and findable to anyone downloading the release.
- I made a note about your branch names being based on git flow conventions, but you aren't strictly following git flow.  Consider updating your practice to follow existing conventions (there is a git flow plugin for command line git if you use that).  Please review/revise to make sure what I've written is accurate to how you're using branches.

Some other questions:
- Which version of JUCE/Projucer are you using (personal, educational)? Any recommendation for what developers should use if they want to work with the bitKlavier code?
- The resource folder directions say that the folder must be in `~/Documents` - where does it go on a non-Mac?
- Have you tested the development setup on other platforms besides OSX? (It's ok if you haven't, but worth noting that it's not currently tested / unknown status, or some such)
