### PR TITLE
Added linux support

### DIFF
--- a/bk_JUCE/bitKlavier/JuceLibraryCode/AppConfig.h
+++ b/bk_JUCE/bitKlavier/JuceLibraryCode/AppConfig.h
@@ -214,12 +214,20 @@
  //#define JUCE_USE_CURL 0
 #endif
 
+#ifndef    JUCE_LOAD_CURL_SYMBOLS_LAZILY
+ //#define JUCE_LOAD_CURL_SYMBOLS_LAZILY 0
+#endif
+
 #ifndef    JUCE_CATCH_UNHANDLED_EXCEPTIONS
  //#define JUCE_CATCH_UNHANDLED_EXCEPTIONS 1
 #endif
 
 #ifndef    JUCE_ALLOW_STATIC_NULL_VARIABLES
  //#define JUCE_ALLOW_STATIC_NULL_VARIABLES 1
+#endif
+
+#ifndef    JUCE_STRICT_REFCOUNTEDPOINTER
+ //#define JUCE_STRICT_REFCOUNTEDPOINTER 0
 #endif
 
 //==============================================================================
@@ -238,6 +246,10 @@
 
 #ifndef    JUCE_USE_DIRECTWRITE
  //#define JUCE_USE_DIRECTWRITE 1
+#endif
+
+#ifndef    JUCE_DISABLE_COREGRAPHICS_FONT_SMOOTHING
+ //#define JUCE_DISABLE_COREGRAPHICS_FONT_SMOOTHING 0
 #endif
 
 //==============================================================================
@@ -284,6 +296,10 @@
 #ifndef    JUCE_USE_CAMERA
  //#define JUCE_USE_CAMERA 0
 #endif
+
+#ifndef    JUCE_SYNC_VIDEO_VOLUME_WITH_OS_MEDIA_VOLUME
+ //#define JUCE_SYNC_VIDEO_VOLUME_WITH_OS_MEDIA_VOLUME 1
+#endif
 //==============================================================================
 #ifndef    JUCE_STANDALONE_APPLICATION
  #if defined(JucePlugin_Name) && defined(JucePlugin_Build_Standalone)
@@ -316,6 +332,9 @@
 #endif
 #ifndef  JucePlugin_Build_Standalone
  #define JucePlugin_Build_Standalone       1
+#endif
+#ifndef  JucePlugin_Build_Unity
+ #define JucePlugin_Build_Unity            0
 #endif
 #ifndef  JucePlugin_Enable_IAA
  #define JucePlugin_Enable_IAA             1

--- a/bk_JUCE/bitKlavier/JuceLibraryCode/JuceHeader.h
+++ b/bk_JUCE/bitKlavier/JuceLibraryCode/JuceHeader.h
@@ -44,6 +44,7 @@
 namespace ProjectInfo
 {
     const char* const  projectName    = "bitKlavier";
+    const char* const  companyName    = "manyarrowsmusic";
     const char* const  versionString  = "2.2-beta.1";
     const int          versionNumber  = 0x20201;
 }

--- a/bk_JUCE/bitKlavier/Source/BKConstructionSite.cpp
+++ b/bk_JUCE/bitKlavier/Source/BKConstructionSite.cpp
@@ -322,9 +322,7 @@ void BKConstructionSite::addItem(BKPreparationType type, bool center)
     
 #if JUCE_IOS
     toAdd->setTopLeftPosition(lastX, lastY);
-#endif
-    
-#if JUCE_MAC || JUCE_WINDOWS
+#else
     if (center)
     {
         toAdd->setTopLeftPosition(300, 250);

--- a/bk_JUCE/bitKlavier/Source/General.h
+++ b/bk_JUCE/bitKlavier/Source/General.h
@@ -31,9 +31,7 @@ public:
 
 #if JUCE_IOS
         globalGain = 0.75;
-#endif
-        
-#if JUCE_MAC || JUCE_WINDOWS
+#else
         globalGain = 1.0;
 #endif
     }

--- a/bk_JUCE/bitKlavier/Source/HeaderViewController.cpp
+++ b/bk_JUCE/bitKlavier/Source/HeaderViewController.cpp
@@ -329,7 +329,7 @@ void HeaderViewController::galleryMenuCallback(int result, HeaderViewController*
 
 		gvc->fillGalleryCB();
 	}
-#if !JUCE_WINDOWS
+#if (JUCE_MAC || JUCE_IOS)
 	else if (result == SHARE_EMAIL_ID)
 	{
 		gvc->bot.share(processor.gallery->getURL(), 0);
@@ -553,7 +553,7 @@ void HeaderViewController::fillGalleryCB(void)
         
         File moreGalleries = File::getSpecialLocation(File::userDocumentsDirectory);
         
-#if JUCE_MAC || JUCE_WINDOWS
+#if JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX
         bkGalleries = bkGalleries.getSpecialLocation(File::userDocumentsDirectory).getChildFile("bitKlavier resources").getChildFile("galleries");
 #endif
         

--- a/bk_JUCE/bitKlavier/Source/HeaderViewController.h
+++ b/bk_JUCE/bitKlavier/Source/HeaderViewController.h
@@ -47,7 +47,7 @@ private:
     
     int galleryIsDirtyAlertResult;
     
-#if !JUCE_WINDOWS
+#if (JUCE_MAC || JUCE_IOS)
     ShareBot bot;
 #endif
     

--- a/bk_JUCE/bitKlavier/Source/PluginProcessor.cpp
+++ b/bk_JUCE/bitKlavier/Source/PluginProcessor.cpp
@@ -92,10 +92,7 @@ shouldLoadDefault(true)
 #if JUCE_IOS
     platform = BKIOS;
     lastGalleryPath = lastGalleryPath.getSpecialLocation(File::userDocumentsDirectory);
-#endif
- 
-
-#if JUCE_MAC || JUCE_WINDOWS
+#else
     platform = BKOSX;
     lastGalleryPath = lastGalleryPath.getSpecialLocation(File::userDocumentsDirectory).getChildFile("bitKlavier resources").getChildFile("galleries");
 
@@ -349,9 +346,7 @@ void BKAudioProcessor::createNewGallery(String name, ScopedPointer<XmlElement> x
 
 #if JUCE_IOS
     bkGalleries = bkGalleries.getSpecialLocation(File::userDocumentsDirectory);
-#endif
-    
-#if JUCE_MAC || JUCE_WINDOWS
+#else
     bkGalleries = bkGalleries.getSpecialLocation(File::userDocumentsDirectory).getChildFile("bitKlavier resources").getChildFile("galleries");
 #endif
     

--- a/bk_JUCE/bitKlavier/bitKlavier.jucer
+++ b/bk_JUCE/bitKlavier/bitKlavier.jucer
@@ -458,9 +458,34 @@
         <MODULEPATH id="juce_audio_devices" path="..\..\..\JUCE\modules"/>
         <MODULEPATH id="juce_audio_basics" path="..\..\..\JUCE\modules"/>
         <MODULEPATH id="stk" path="..\..\..\JUCE\modules"/>
-        <MODULEPATH id="SFZero" path="..\..\..\JUCE\modules\SFZero\modules"/>
+        <MODULEPATH id="SFZero" path="..\..\..\JUCE\modules"/>
       </MODULEPATHS>
     </VS2017>
+    <LINUX_MAKE targetFolder="Builds/LinuxMakefile">
+      <CONFIGURATIONS>
+        <CONFIGURATION isDebug="1" name="Debug"/>
+        <CONFIGURATION isDebug="0" name="Release"/>
+      </CONFIGURATIONS>
+      <MODULEPATHS>
+        <MODULEPATH id="SFZero" path="../../../Documents/custom_modules/SFZero/SFZero/modules"/>
+        <MODULEPATH id="stk" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_video" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_opengl" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_gui_extra" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_gui_basics" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_graphics" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_events" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_data_structures" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_cryptography" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_core" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_utils" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_processors" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_plugin_client" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_formats" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_devices" path="../../../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_basics" path="../../../JUCE/modules"/>
+      </MODULEPATHS>
+    </LINUX_MAKE>
   </EXPORTFORMATS>
   <MODULES>
     <MODULE id="juce_audio_basics" showAllCode="1" useLocalCopy="0"/>


### PR DESCRIPTION
This is the changes Mike and I made to get the bitklavier running on linux. As long as you have JUCE/projucer it should be installable by calling `make` in Builds/LinuxMakefile. I could also do a write up on how to get JUCE working on Fedora since the documentation for installing it on linux is sparse.